### PR TITLE
Make the configuration work on Linux

### DIFF
--- a/init.el
+++ b/init.el
@@ -15,7 +15,8 @@
 (require 'packages)
 
 ;; Configure Emacs for Norwegian OSX, lol
-(require 'norwegian-mac)
+(when (string= "darwin" system-type)
+  (require 'norwegian-mac))
 
 ;; Lets start with a smattering of sanity
 (require 'sane-defaults)

--- a/users/sigmund/sigmund.el
+++ b/users/sigmund/sigmund.el
@@ -1,0 +1,24 @@
+;; Custom own settings
+
+;;Configure pair-programming-mode
+(setq my/pair-programming-myself '("Sigmund Hansen"))
+
+;; PlantUML
+(use-package plantuml-mode)
+(use-package flycheck-plantuml)
+
+(setq plantuml-jar-path
+      (concat (expand-file-name "~/bin/")
+              "plantuml.jar"))
+(setq plantuml-default-exec-mode 'jar)
+(add-to-list 'auto-mode-alist '("\\.plantuml\\'" . plantuml-mode))
+
+(with-eval-after-load 'org
+  (add-to-list 'org-src-lang-modes '("plantuml" . plantuml)))
+
+(with-eval-after-load 'flycheck
+  (require 'flycheck-plantuml)
+  (flycheck-plantuml-setup))
+
+;; Side by side ediff
+(setq ediff-split-window-function 'split-window-vertically)


### PR DESCRIPTION
Or rather any system that doesn't have gls as a GNU version of ls. On Linux ls is GNU ls on pretty much every distro. The Mac specific keyboard settings do not make sense on Linux or Windows either, but I haven't noticed any problem with them, as there is no such thing as cmd, opt, etc.