### PR TITLE
Make the configuration work on Linux

### DIFF
--- a/init.el
+++ b/init.el
@@ -15,7 +15,8 @@
 (require 'packages)
 
 ;; Configure Emacs for Norwegian OSX, lol
-(require 'norwegian-mac)
+(when (string= "darwin" system-type)
+  (require 'norwegian-mac))
 
 ;; Lets start with a smattering of sanity
 (require 'sane-defaults)


### PR DESCRIPTION
Or rather any system that doesn't have gls as a GNU version of ls. On Linux ls is GNU ls on pretty much every distro. The Mac specific keyboard settings do not make sense on Linux or Windows either, but I haven't noticed any problem with them, as there is no such thing as cmd, opt, etc.